### PR TITLE
feat: validate button send comment

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-key */
 import { Post } from "./components/Post";
 import { Header } from "./components/Header";
 import { Sidebar } from "./components/Sidebar";

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-key */
 /* eslint-disable react/prop-types */
 import { useState } from "react";
 import { Avatar } from "./Avatar";
@@ -39,6 +38,8 @@ export function Post({ author, publishedAt, content }) {
         
         setComments(commentsWithoutDeletedOne);
     }
+
+    const isNewCommentEmpty = newCommentText.length === 0;
 
     return (
         <article className={styles.post}>
@@ -83,10 +84,15 @@ export function Post({ author, publishedAt, content }) {
                     onChange={handleNewCommentChange} 
                     name="inputComment" 
                     placeholder="Deixe um comentário" 
+                    required
                 />
 
                 <footer>
-                    <button type="submit">Publicar</button>
+                    <button 
+                        type="submit" 
+                        disabled={isNewCommentEmpty}>
+                            Publicar
+                        </button>
                 </footer>
             </form>
 

--- a/src/components/Post.module.css
+++ b/src/components/Post.module.css
@@ -104,8 +104,13 @@
     transition: 0.1s;
 }
 
-.commentForm button[type=submit]:hover {
+.commentForm button[type=submit]:not(:disabled):hover {
     background: var(--green-300);
+}
+
+.commentForm button:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
 }
 
 .commentList {


### PR DESCRIPTION
Adiciona funcionalidade de validar o botão do formulario de comentarios. Se o campo estiver vazio, não é possivel enviar comentarios.